### PR TITLE
Safe creation of Ratios with non zero denominators

### DIFF
--- a/ultra-core/quickcheck/Main.hs
+++ b/ultra-core/quickcheck/Main.hs
@@ -3,7 +3,9 @@ module Main where
 import qualified Test.Ultra.Control.Applicative
 import qualified Test.Ultra.Data.Either
 import qualified Test.Ultra.Data.Foldable
+import qualified Test.Ultra.Data.NonZero
 import qualified Test.Ultra.Data.Ord
+import qualified Test.Ultra.Data.Ratio
 import qualified Test.Ultra.Data.RealFrac
 
 import Lab.Core.Main
@@ -15,6 +17,8 @@ main = labMain
     [   Test.Ultra.Control.Applicative.tests
     ,   Test.Ultra.Data.Either.tests
     ,   Test.Ultra.Data.Foldable.tests
+    ,   Test.Ultra.Data.NonZero.tests
     ,   Test.Ultra.Data.Ord.tests
+    ,   Test.Ultra.Data.Ratio.tests
     ,   Test.Ultra.Data.RealFrac.tests
     ]

--- a/ultra-core/quickcheck/Test/Ultra/Data/NonZero.hs
+++ b/ultra-core/quickcheck/Test/Ultra/Data/NonZero.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+-------------------------------------------------------------------
+-- |
+-- Module       : Test.Ultra.Data.NonZero
+-- Copyright    : (C) 2017
+-- License      : BSD-style (see the file etc/LICENSE.md)
+-- Maintainer   : Dom De Re
+--
+-------------------------------------------------------------------
+module Test.Ultra.Data.NonZero where
+
+import Lab.Core.Property ((=/=))
+import Lab.Core.QuickCheck (
+    Arbitrary(..)
+  , Gen
+  , Property
+  , (===)
+  , conjoin
+  , forAll
+  , suchThat
+  )
+import Lab.Core.QuickCheck.TH (quickCheckAll)
+
+import Ultra.Data.NonZero (
+    NonZero
+  , nonZero
+  , getNonZero
+  )
+
+import Preamble
+
+prop_nonZero_zero :: Property
+prop_nonZero_zero = nonZero (0 :: Int) === Nothing
+
+prop_nonZero_notZero :: Property
+prop_nonZero_notZero = forAll (arbitrary `suchThat` (/= 0) :: Gen Int) $ \x ->
+  let
+    n :: Maybe (NonZero Int)
+    n = nonZero x
+  in conjoin [
+      n =/= Nothing
+    , (getNonZero <$> n) === pure x
+    
+    ]
+
+return []
+tests :: IO Bool
+tests = $quickCheckAll

--- a/ultra-core/quickcheck/Test/Ultra/Data/Ratio.hs
+++ b/ultra-core/quickcheck/Test/Ultra/Data/Ratio.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+-------------------------------------------------------------------
+-- |
+-- Module       : Test.Ultra.Data.Ratio
+-- Copyright    : (C) 2017
+-- License      : BSD-style (see the file etc/LICENSE.md)
+-- Maintainer   : Dom De Re
+--
+-------------------------------------------------------------------
+module Test.Ultra.Data.Ratio where
+
+import Lab.Core.QuickCheck (Arbitrary(..), Property, (===), forAll, suchThat)
+import Lab.Core.QuickCheck.TH (quickCheckAll)
+
+import Ultra.Data.Ratio ((%?))
+
+import Data.Ratio ((%))
+
+import Preamble
+
+prop_maybeRatio_zeroDenom :: Int -> Property
+prop_maybeRatio_zeroDenom n = (n %? 0) === Nothing
+
+prop_maybeRatio_nonZeroDenom :: Int -> Property
+prop_maybeRatio_nonZeroDenom n = forAll (arbitrary `suchThat` (/= 0)) $ \d ->
+  (n %? d) === pure (n % d)
+
+return []
+tests :: IO Bool
+tests = $quickCheckAll

--- a/ultra-core/src/Ultra/Data/NonZero.hs
+++ b/ultra-core/src/Ultra/Data/NonZero.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+-------------------------------------------------------------------
+-- |
+-- Module       : Ultra.Data.NonZero
+-- Copyright    : (C) 2017
+-- License      : BSD-style (see the file etc/LICENSE.md)
+-- Maintainer   : Dom De Re
+--
+-------------------------------------------------------------------
+module Ultra.Data.NonZero (
+  -- * Types
+    NonZero
+  -- * Functions
+  , nonZero
+  , getNonZero
+  ) where
+
+import Preamble
+
+newtype NonZero a = NonZero a
+  deriving (Show, Eq)
+
+nonZero
+  :: (Eq a, Integral a)
+  => a
+  -> Maybe (NonZero a)
+nonZero 0 = Nothing
+nonZero n = pure $ NonZero n
+
+getNonZero :: NonZero a -> a
+getNonZero (NonZero x) = x
+

--- a/ultra-core/src/Ultra/Data/Ratio.hs
+++ b/ultra-core/src/Ultra/Data/Ratio.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+-------------------------------------------------------------------
+-- |
+-- Module       : Ultra.Data.Ratio
+-- Copyright    : (C) 2017
+-- License      : BSD-style (see the file etc/LICENSE.md)
+-- Maintainer   : Dom De Re
+--
+-------------------------------------------------------------------
+module Ultra.Data.Ratio (
+  -- * Operators
+    (%!)
+  , (%?)
+  ) where
+
+import Ultra.Data.NonZero (
+    NonZero
+  , getNonZero
+  , nonZero
+  )
+
+import Data.Ratio (Ratio, (%))
+
+import Preamble
+
+infixl 7 %!
+infixl 7 %?
+
+(%!) :: (Integral a) => a -> NonZero a -> Ratio a
+num %! denom = num % (getNonZero denom)
+
+(%?) :: (Integral a) => a -> a -> Maybe (Ratio a)
+num %? denom = (num %!) <$> nonZero denom

--- a/ultra-core/ultra-core.cabal
+++ b/ultra-core/ultra-core.cabal
@@ -17,7 +17,7 @@ build-type:         Simple
 
 source-repository       head
     type:               git
-    location:           https://github.com/domdere/ultra/ultra-base
+    location:           https://github.com/domdere/ultra.git
 
 flag                    small_base
     description:        Choose the new, split-up base package.
@@ -39,7 +39,9 @@ library
                         Ultra.Data.Either
                         Ultra.Data.Foldable
                         Ultra.Data.List
+                        Ultra.Data.NonZero
                         Ultra.Data.Ord
+                        Ultra.Data.Ratio
                         Ultra.Data.RealFrac
 
     default-extensions: NoImplicitPrelude


### PR DESCRIPTION
- ultra-core
    - `NonZero`
        - check if an `Integral` is non zero
    - `%!` and `%?`: safely create a `Ratio` with non zero denominator
    - tests for both